### PR TITLE
adding typespecs

### DIFF
--- a/lib/gen_fsm.ex
+++ b/lib/gen_fsm.ex
@@ -1,10 +1,75 @@
 defmodule GenFSM do
-  @doc false
+  @type event :: term
+  @type state_name :: atom
+  @type state_data :: term
+  @type next_state_name :: atom
+  @type new_state_data :: term
+  @type reply :: term
+  @type reason :: term
 
+  @callback init(args :: term) ::
+    {:ok, state_name, state_data} |
+    {:ok, state_name, state_data, timeout | :hibernate} |
+    :ignore |
+    {:stop, reason}
+
+  @callback handle_event(event, state_name, state_data) ::
+    {:next_state, next_state_name, new_state_data} |
+    {:next_state, next_state_name, new_state_data, timeout} |
+    {:next_state, next_state_name, new_state_data, :hibernate} |
+    {:stop, reason, new_state_data} when new_state_data: term
+
+  @callback handle_sync_event(event, from, state_name, state_data) ::
+    {:reply, reply, next_state_name, new_state_data} |
+    {:reply, reply, next_state_name, new_state_data, timeout} |
+    {:reply, reply, next_state_name, new_state_data, :hibernate} |
+    {:next_state, next_state_name, new_state_data} |
+    {:next_state, next_state_name, new_state_data, timeout} |
+    {:next_state, next_state_name, new_state_data, :hibernate} |
+    {:stop, reason, reply, new_state_data} |
+    {:stop, reason, new_state_data} when new_state_data: term
+
+  @callback handle_info(info :: term, state_name, state_data) ::
+    {:next_state, next_state_name, new_state_data} |
+    {:next_state, next_state_name, new_state_data, timeout} |
+    {:next_state, next_state_name, new_state_data, :hibernate} |
+    {:stop, reason, new_state_data} when new_state_data: term
+
+  @callback terminate(reason, state_name, state_data) ::
+    term when reason: :normal | :shutdown | {:shutdown, term} | term
+
+  @callback code_change(old_vsn, state_name, state_data, extra :: term) ::
+    {:ok, next_state_name, new_state_data} |
+    {:error, reason} when old_vsn: term |
+    {:down, term}
+
+  @typedoc "Return values of `start*` functions"
+  @type on_start :: {:ok, pid} | :ignore | {:error, {:already_started, pid} | term}
+
+  @typedoc "Options used by the `start*` functions"
+  @type options :: [option]
+
+  @typedoc "Option values used by the `start*` functions"
+  @type option :: {:debug, debug} |
+                  {:name, name} |
+                  {:timeout, timeout} |
+                  {:spawn_opt, Process.spawn_opt}
+
+  @typedoc "The GenFSM name"
+  @type name :: atom | {:global, term} | {:via, module, term}
+
+  @typedoc "Debug options supported by the `start*` functions"
+  @type debug :: [:trace | :log | :statistics | {:log_to_file, Path.t} | {:install, {fun, any}}]
+
+  @typedoc "The fsm reference"
+  @type fsm_ref :: name | {name, node} | pid()
+
+  @spec start_link(module, any, options) :: on_start
   def start_link(module, args, options \\ []) when is_atom(module) and is_list(options) do
     do_start(:link, module, args, options)
   end
 
+  @spec start(module, any, options) :: on_start
   def start(module, args, options \\ []) when is_atom(module) and is_list(options) do
     do_start(:nolink, module, args, options)
   end
@@ -20,69 +85,80 @@ defmodule GenFSM do
     end
   end
 
+  @spec stop(fsm_ref, reason :: term, timeout) :: :ok
   def stop(fsm, reason \\ :normal, timeout \\ :infinity) do
     :gen.stop(fsm, reason, timeout)
   end
 
+  @spec send_event(fsm_ref, event) :: :ok
   def send_event(fsm, event) do
     :gen_fsm.send_event(fsm, event)
   end
 
+  @spec send_all_state_event(fsm_ref, event) :: :ok
   def send_all_state_event(fsm, event) do
     :gen_fsm.send_all_state_event(fsm, event)
   end
 
+  @spec sync_send_event(fsm_ref, event, timeout) :: :ok
   def sync_send_event(fsm, event, timeout \\ 5000) do
     :gen_fsm.sync_send_event(fsm, event, timeout)
   end
 
+  @spec sync_send_all_state_event(fsm_ref, event, timeout) :: :ok
   def sync_send_all_state_event(fsm, event, timeout \\ 5000) do
     :gen_fsm.sync_send_all_state_event(fsm, event, timeout)
   end
 
+  @type from :: {pid, tag :: term}
+  @spec reply(from, term) :: :ok
   def reply(caller, reply) do
     :gen_fsm.reply(caller, reply)
   end
 
+  @spec send_event_after(integer, event) :: reference
   def send_event_after(time, event) do
     :gen_fsm.send_event_after(time, event)
   end
 
+  @spec start_timer(integer, term) :: reference
   def start_timer(time, message) do
     :gen_fsm.start_timer(time, message)
   end
 
+  @type remaining_time :: integer
+  @spec cancel_timer(reference) :: remaining_time | false
   def cancel_timer(timer_ref) do
     :gen_fsm.cancel_timer(timer_ref)
   end
 
   defmacro __using__(_) do
     quote location: :keep do
-     @behaviour :gen_fsm
+      @behaviour :gen_fsm
 
       @doc false
-      def handle_event(event, state_name, state_data) do
-        { :stop, {:bad_event, state_name, event}, state_data }
+      def handle_event(_event, _state_name, state_data) do
+        {:stop, :unexpected_event, state_data}
       end
 
       @doc false
-      def handle_sync_event(event, from, state_name, state_data) do
-        { :stop, {:bad_sync_event, state_name, event}, state_data }
+      def handle_sync_event(_event, _from, _state_name, state_data) do
+        {:stop, :unexpected_event, state_data}
       end
 
       @doc false
-      def handle_info(_msg, state_name, state_data) do
-        { :next_state, state_name, state_data }
+      def handle_info(_info, _state_name, state_data) do
+        {:stop, :unexpected_message, state_data}
       end
 
       @doc false
-      def terminate(_reason, _state_name, _state_data) do
-        :ok
+      def terminate(reason, _state_name, _state_data) do
+        reason
       end
 
       @doc false
       def code_change(_old, state_name, state_data, _extra) do
-        { :ok, state_name, state_data }
+        {:ok, state_name, state_data}
       end
 
       defoverridable [handle_event: 3, handle_sync_event: 4,

--- a/test/gen_fsm_test.exs
+++ b/test/gen_fsm_test.exs
@@ -16,7 +16,7 @@ defmodule GenFsmTest do
       assert { :ok, pid } = GenFSM.start_link(Sample, [:hello], [])
 
       catch_exit(:gen_fsm.sync_send_all_state_event(pid, :unknown_request))
-      assert_receive { :EXIT, ^pid, {:bad_sync_event, :sample, :unknown_request} }
+      assert_receive {:EXIT, ^pid, :unexpected_event}
     end
   after
     Process.flag(:trap_exit, false)
@@ -28,10 +28,9 @@ defmodule GenFsmTest do
       assert { :ok, pid } = GenFSM.start_link(Sample, [:hello], [])
 
       :gen_fsm.send_all_state_event(pid, :unknown_request)
-      assert_receive { :EXIT, ^pid, {:bad_event, :sample, :unknown_request} }
+      assert_receive {:EXIT, ^pid, :unexpected_event}
     end
   after
     Process.flag(:trap_exit, false)
   end
 end
-

--- a/test/turnstile_example_test.exs
+++ b/test/turnstile_example_test.exs
@@ -1,0 +1,92 @@
+defmodule GenFSM.TurnstileExampleTest do
+  use ExUnit.Case
+
+  # A module that implement a turnstile that let a person enter if
+  # a coin has been inserted into the turnstile; no access will be
+  # granted if no coins has been inserted. If multiple coins are
+  # inserted it will only let one person through, it is greedy like
+  # that.
+  defmodule Turnstile do
+    use GenFSM
+
+    # Initialize the turnstile state machine with zero coins
+    def start_link do
+      GenFSM.start_link(__MODULE__, 0)
+    end
+
+    # Public API
+    # The user can enter and insert_coins into our turnstile. The
+    # outcome of these actions depends on the state of the turnstile
+    # lock.
+    def enter(pid) do
+      GenFSM.sync_send_event(pid, :enter)
+    end
+    def insert_coin(pid) do
+      GenFSM.send_event(pid, :coin)
+    end
+    def empty(pid) do
+      GenFSM.sync_send_event(pid, :empty)
+    end
+
+    # Internal API
+    def init(number_of_coins) do
+      # Initialize the turnstile state machine in the locked state.
+      # The state machine is initialized with a given number of
+      # coins in its bank.
+      {:ok, :locked, number_of_coins}
+    end
+
+    def unlocked(:coin, state) do
+      # If another coin is inserted we will just eat the coin.
+      {:next_state, :unlocked, state + 1}
+    end
+    def unlocked(:enter, _from, state) do
+      # One can enter the door when it is unlocked, but it will switch
+      # state to locked when the door has been entered.
+      {:reply, :access_allowed, :locked, state}
+    end
+
+    def locked(:coin, state) do
+      # Increment the bank and set the state to unlocked, allowing
+      # someone to enter.
+      {:next_state, :unlocked, state + 1}
+    end
+    def locked(:enter, _from, state) do
+      # The door will not let anyone enter before it has been unlocked
+      # by inserting a coin. Entering in this state will not to
+      # anything.
+      {:reply, :access_denied, :locked, state}
+    end
+    def locked(:empty, _from, state) do
+      # The turnstile can be emptied when it is locked. This will reset
+      # the bank to zero and return the number of coins (we do not take
+      # authorization into consideration here). When the turnstile is
+      # emptied it will remain in the locked state.
+      {:reply, state, :locked, 0}
+    end
+  end
+
+  test "turnstile example" do
+    assert {:ok, pid} = Turnstile.start_link()
+
+    # turnstile bank should initialize as empty
+    assert Turnstile.empty(pid) == 0
+
+    # let's try to enter without inserting a coin
+    assert Turnstile.enter(pid) == :access_denied
+
+    # lets insert some coins
+    Turnstile.insert_coin(pid)
+    Turnstile.insert_coin(pid)
+    Turnstile.insert_coin(pid)
+
+    # it should allow entry once; the second time it should deny
+    assert Turnstile.enter(pid) == :access_allowed
+    assert Turnstile.enter(pid)  == :access_denied
+
+    # let's check the bank!
+    assert Turnstile.empty(pid) == 3
+    # turnstile bank should now be empty
+    assert Turnstile.empty(pid) == 0
+  end
+end


### PR DESCRIPTION
I have added some typespecs.

They are not complete yet, I miss `handle_event/3`, `handle_sync_event/4` `handle_info/3`, and `code_change/4`.

I have looked at the implementation for the Elixir core gen_server wrapper, and I've tried to follow the Erlang documentation on the different specs for the functions. I am not 100% sure they are correct.

It's a start. You can let this pull request linger and I'll get back to adding specs for the remaining callbacks. Perhaps I need to reorder some of the specs and types, and use the types for state_name and state_data consistently.
