### PR TITLE
Added an example with a keypad lock

### DIFF
--- a/examples/code_lock/.gitignore
+++ b/examples/code_lock/.gitignore
@@ -1,0 +1,5 @@
+/_build
+/cover
+/deps
+erl_crash.dump
+*.ez

--- a/examples/code_lock/README.md
+++ b/examples/code_lock/README.md
@@ -1,0 +1,9 @@
+# Code Lock
+
+An Elixir port of the Code Lock example found in the Erlang OTP documentation.
+
+  * http://erlang.org/doc/design_principles/fsm.html
+
+This link contain explanation of the code.
+
+Remember to run `mix deps.get` in the example folder and have a look in the test file for usage.

--- a/examples/code_lock/lib/code_lock.ex
+++ b/examples/code_lock/lib/code_lock.ex
@@ -1,0 +1,40 @@
+defmodule CodeLock do
+  use GenFSM
+
+  def start_link(code) do
+    GenFSM.start_link(__MODULE__, Enum.reverse(code))
+  end
+
+  def button(pid, digit) do
+    IO.puts "beeep!"
+    GenFSM.send_event(pid, {:button, digit})
+  end
+
+  def init(code) do
+    {:ok, :locked, {[], code}}
+  end
+
+  def locked({:button, digit}, {so_far, code}) do
+    IO.inspect {:state, [digit | so_far], code}
+    case [digit | so_far] do
+      ^code ->
+        # do_unlock(...)
+        IO.puts "unlocked!"
+        {:next_state, :open, {[], code}, 1000}
+
+      incomplete when length(incomplete) < length(code) ->
+        IO.puts "awaiting more digits"
+        {:next_state, :locked, {incomplete, code}}
+
+      _wrong ->
+        IO.puts "wrong!"
+        {:next_state, :locked, {[], code}}
+    end
+  end
+
+  def open(:timeout, state) do
+    # do_lock(...)
+    IO.puts "SLAM! locked!"
+    {:next_state, :locked, state}
+  end
+end

--- a/examples/code_lock/mix.exs
+++ b/examples/code_lock/mix.exs
@@ -1,0 +1,20 @@
+defmodule CodeLock.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :code_lock,
+     version: "0.0.1",
+     elixir: "~> 1.2",
+     build_embedded: Mix.env == :prod,
+     start_permanent: Mix.env == :prod,
+     deps: deps]
+  end
+
+  def application do
+    [applications: [:logger]]
+  end
+
+  defp deps do
+    [{:gen_fsm, "~> 0.1"}]
+  end
+end

--- a/examples/code_lock/mix.lock
+++ b/examples/code_lock/mix.lock
@@ -1,0 +1,1 @@
+%{"gen_fsm": {:hex, :gen_fsm, "0.1.0", "5097308e244e25dbb2aa0ee5b736bb1ab79c3f8ca889a9e5b3aabd8beee6fc88", [:mix], []}}

--- a/examples/code_lock/test/code_lock_test.exs
+++ b/examples/code_lock/test/code_lock_test.exs
@@ -1,0 +1,21 @@
+defmodule CodeLockTest do
+  use ExUnit.Case
+
+  test "punch in those numbers and await the timeout" do
+    {:ok, pid} = CodeLock.start_link([1,2,3,4])
+
+    CodeLock.button(pid, 1)
+    :timer.sleep 10
+    CodeLock.button(pid, 2)
+    :timer.sleep 10
+    CodeLock.button(pid, 3)
+    :timer.sleep 10
+    CodeLock.button(pid, 4)
+    # we should be open by now
+
+    # wait for the timer...
+    :timer.sleep 1100
+
+    IO.puts "done!"
+  end
+end

--- a/examples/code_lock/test/test_helper.exs
+++ b/examples/code_lock/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
A question was raised about this on the Elixir Forum.
- http://elixirforum.com/t/genfsm-an-elixir-wrapper-for-the-gen-fsm-behaviour/534/2

I ported it so why not add it as an example in the example folder?
